### PR TITLE
add promise types for CredentialsGetter

### DIFF
--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -124,7 +124,7 @@ const createLinkWithStore = (createLinkFunc = (store: Store<OfflineCacheType>) =
     });
 }
 
-type CredentialsGetter = () => (Credentials | CredentialsOptions | null) | Credentials | CredentialsOptions | null;
+type CredentialsGetter = () => (Credentials | CredentialsOptions | Promise<Credentials> | Promise<CredentialsOptions> | null) | Credentials | CredentialsOptions | Promise<Credentials> | Promise<CredentialsOptions> | null;
 
 export interface AWSAppSyncClientOptions {
     url: string,


### PR DESCRIPTION


*Issue #, if available:*
264

*Description of changes:*
add promised version as valid types for CredentialsGetter - see https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/264

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
